### PR TITLE
Add SFML Vulkan availability check

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -109,9 +109,11 @@ static inline void chk(bool result) {
 int main(int argc, char* argv[])
 {
 	volkInitialize();
+	chk(sf::Vulkan::isAvailable(true));
 	// Instance
 	VkApplicationInfo appInfo{ .sType = VK_STRUCTURE_TYPE_APPLICATION_INFO, .pApplicationName = "How to Vulkan", .apiVersion = VK_API_VERSION_1_3 };
 	const std::vector<const char*> instanceExtensions{ sf::Vulkan::getGraphicsRequiredInstanceExtensions() };
+	chk(!instanceExtensions.empty());
 	VkInstanceCreateInfo instanceCI{
 		.sType = VK_STRUCTURE_TYPE_INSTANCE_CREATE_INFO,
 		.pApplicationInfo = &appInfo,


### PR DESCRIPTION
If SFML is built without Vulkan support, find out as early as possible rather than fail at surface creation.

I went down a deep rabbit hole on macOS tracking down surface creation failure.

Side note, you might consider `sf::WindowBase` instead of `sf::RenderWindow` just to prevent an OpenGL context from being created.