### PR TITLE
Fix slang session excerpt and minor text improvements

### DIFF
--- a/tutorial/docs/index.md
+++ b/tutorial/docs/index.md
@@ -911,7 +911,7 @@ Now that we have uploaded the texture images, put them into the correct layout a
 
 In earlier Vulkan versions we would also have to use them for buffers, but as noted in the [shader data buffers](#shader-data-buffers) chapter, buffer device address saves us from doing that. There's no easy to use or widely available equivalent to that for images yet.
 
-And while descriptor handling is still one of the most verbose parts, using [Descriptor indexing](https://docs.vulkan.org/refpages/latest/refpages/source/VK_EXT_descriptor_indexing.html), simplifies this significantly respectively makes it easier to scale. With that feature we can go for a "bindless" setup, where all textures are put into one large array and indexed in the [shader](#the-shader) rather than having to create and bind descriptor sets for each and every texture. To demonstrate how this works we'll be loading multiple textures. This approach scales up no matter how many textures you use (within the limits of what the GPU supports).
+And while descriptor handling is still one of the most verbose parts, using [Descriptor indexing](https://docs.vulkan.org/refpages/latest/refpages/source/VK_EXT_descriptor_indexing.html) can simplify this significantly and makes it easier to scale. With that feature we can go for a "bindless" setup, where all textures are put into one large array and indexed in the [shader](#the-shader) rather than having to create and bind descriptor sets for each and every texture. To demonstrate how this works we'll be loading multiple textures. This approach scales up no matter how many textures you use (within the limits of what the GPU supports).
 
 First we define the interface between our application and the shader in the form of a descriptor set layout:
 
@@ -1021,11 +1021,11 @@ auto slangOptions{ std::to_array<slang::CompilerOptionEntry>({ {
 	{slang::CompilerOptionValueKind::Int, 1}
 } }) };
 slang::SessionDesc slangSessionDesc{
-	.targets{targets.data()},
-	.targetCount{SlangInt(targets.size())},
+	.targets{slangTargets.data()},
+	.targetCount{SlangInt(slangTargets.size())},
 	.defaultMatrixLayoutMode = SLANG_MATRIX_LAYOUT_COLUMN_MAJOR,
-	.compilerOptionEntries{slangTargets.data()},
-	.compilerOptionEntryCount{uint32_t(slangTargets.size())}
+	.compilerOptionEntries{slangOptions.data()},
+	.compilerOptionEntryCount{uint32_t(slangOptions.size())}
 };
 Slang::ComPtr<slang::ISession> slangSession;
 slangGlobalSession->createSession(slangSessionDesc, slangSession.writeRef());
@@ -1156,7 +1156,7 @@ VkPipelineLayoutCreateInfo pipelineLayoutCI{
 chk(vkCreatePipelineLayout(device, &pipelineLayoutCI, nullptr, &pipelineLayout));
 ```
 
-The [`pushConstantRange`](https://docs.vulkan.org/refpages/latest/refpages/source/VkPushConstantRange.html) defines a range of values that we can directly push to the shader without having to go through a buffer. We use these to pass a pointer to the shader data buffer buffer (more on that later). The descriptor set layouts (`pSetLayouts`) define the interface to the shader resources. In our case that's only one layout for passing the texture image descriptors. The call to [`vkCreatePipelineLayout`](https://docs.vulkan.org/refpages/latest/refpages/source/VkPipelineLayoutCreateInfo.html) will create the pipeline layout we can then use for our pipeline.
+The [`pushConstantRange`](https://docs.vulkan.org/refpages/latest/refpages/source/VkPushConstantRange.html) defines a range of values that we can directly push to the shader without having to go through a buffer. We use these to pass a pointer to the "shader data buffer" buffer (more on that later). The descriptor set layouts (`pSetLayouts`) define the interface to the shader resources. In our case that's only one layout for passing the texture image descriptors. The call to [`vkCreatePipelineLayout`](https://docs.vulkan.org/refpages/latest/refpages/source/VkPipelineLayoutCreateInfo.html) will create the pipeline layout we can then use for our pipeline.
 
 Another part of our interface between the pipeline and the shader is the layout of the vertex data. In the [mesh loading chapter](#loading-meshes) we defined a basic vertex structure that we now need to specify in Vulkan terms. We use a single vertex buffer, so we require one [vertex binding point](https://docs.vulkan.org/refpages/latest/refpages/source/VkVertexInputBindingDescription.html). The `stride` matches the size of our vertex structure as our vertices are stored directly adjacent in memory. The `inputRate` is per-vertex, meaning that the data pointer advances for every vertex read:
 


### PR DESCRIPTION
While following along the tutorial, I found that a Slang session excerpt seemed to not reference the right names and found some bits of text that I thought I could improve.