### PR TITLE
Fix illegal non-uniform descriptor indexing

### DIFF
--- a/source/assets/shader.slang
+++ b/source/assets/shader.slang
@@ -56,6 +56,6 @@ float4 main(VSOutput input) {
     float3 diffuse = max(dot(N, L), 0.0025);
     float3 specular = pow(max(dot(R, V), 0.0), 16.0) * 0.75;
     // Sample from texture
-    float3 color = textures[input.InstanceIndex].Sample(input.UV).rgb * input.Factor;
+    float3 color = textures[NonUniformResourceIndex(input.InstanceIndex)].Sample(input.UV).rgb * input.Factor;
     return float4(diffuse * color.rgb + specular, 1.0);
 }

--- a/source/main.cpp
+++ b/source/main.cpp
@@ -153,7 +153,7 @@ int main(int argc, char* argv[])
 	// Logical device
 	const float qfpriorities{ 1.0f };
 	VkDeviceQueueCreateInfo queueCI{ .sType = VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO, .queueFamilyIndex = queueFamily, .queueCount = 1, .pQueuePriorities = &qfpriorities };
-	VkPhysicalDeviceVulkan12Features enabledVk12Features{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, .descriptorIndexing = true, .descriptorBindingVariableDescriptorCount = true, .runtimeDescriptorArray = true, .bufferDeviceAddress = true };
+	VkPhysicalDeviceVulkan12Features enabledVk12Features{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES, .descriptorIndexing = true, .shaderSampledImageArrayNonUniformIndexing = true, .descriptorBindingVariableDescriptorCount = true, .runtimeDescriptorArray = true, .bufferDeviceAddress = true };
 	VkPhysicalDeviceVulkan13Features enabledVk13Features{ .sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_FEATURES, .pNext = &enabledVk12Features, .synchronization2 = true, .dynamicRendering = true };
 	const std::vector<const char*> deviceExtensions{ VK_KHR_SWAPCHAIN_EXTENSION_NAME };
 	const VkPhysicalDeviceFeatures enabledVk10Features{ .samplerAnisotropy = VK_TRUE };

--- a/tutorial/docs/index.md
+++ b/tutorial/docs/index.md
@@ -254,6 +254,7 @@ Using Vulkan 1.3 as a baseline, we can use the features mentioned [earlier on](#
 VkPhysicalDeviceVulkan12Features enabledVk12Features{
 	.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_FEATURES,
 	.descriptorIndexing = true,
+	.shaderSampledImageArrayNonUniformIndexing = true,
 	.descriptorBindingVariableDescriptorCount = true,
 	.runtimeDescriptorArray = true,
 	.bufferDeviceAddress = true
@@ -269,7 +270,7 @@ const VkPhysicalDeviceFeatures enabledVk10Features{
 };
 ```
 
-`descriptorBindingVariableDescriptorCount` and `runtimeDescriptorArray` are related to descriptor indexing, the rest of the names match the actual feature. We also enable [anisotropic filtering](https://docs.vulkan.org/refpages/latest/refpages/source/VkPhysicalDeviceFeatures.html#_members) for better texture filtering.
+`shaderSampledImageArrayNonUniformIndexing`, `descriptorBindingVariableDescriptorCount` and `runtimeDescriptorArray` are related to descriptor indexing, the rest of the names match the actual feature. We also enable [anisotropic filtering](https://docs.vulkan.org/refpages/latest/refpages/source/VkPhysicalDeviceFeatures.html#_members) for better texture filtering.
 
 !!! Info
 
@@ -1121,7 +1122,7 @@ float4 main(VSOutput input) {
     float3 diffuse = max(dot(N, L), 0.0025);
     float3 specular = pow(max(dot(R, V), 0.0), 16.0) * 0.75;
     // Sample from texture
-    float3 color = textures[input.InstanceIndex].Sample(input.UV).rgb * input.Factor;
+    float3 color = textures[NonUniformResourceIndex(input.InstanceIndex)].Sample(input.UV).rgb * input.Factor;
     return float4(diffuse * color.rgb + specular, 1.0);
 }
 ```


### PR DESCRIPTION
`input.InstanceIndex` isn't dynamically uniform,
so directly using it to index a descriptor array is illegal (and causes visual artifacts).

Fix that by decorating the expression with `NonUniformResourceIndex`. (And ensuring that the relevant device features are enabled).