### PR TITLE
Fix CMake build on MacOS

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -14,7 +14,7 @@ else()
 endif()
 
 # SDL3, Volk, VMA, glm and Slang are taken from the SDK
-include_directories($ENV{VULKAN_SDK}/include)
+include_directories(SYSTEM $ENV{VULKAN_SDK}/include)
 # These are not part of the SDK
 include_directories(external/tinyobj)
 include_directories(external/ktx/include)
@@ -43,7 +43,9 @@ set(KTX_SOURCES
     ${KTX_DIR}/lib/vkloader.c)
 add_library(ktx STATIC ${KTX_SOURCES})
 
-if (NOT WIN32)
+if (APPLE)
+    target_link_libraries(ktx PUBLIC $ENV{VULKAN_SDK}/lib/libvulkan.dylib)
+elseif (NOT WIN32)
     target_link_libraries(ktx PUBLIC $ENV{VULKAN_SDK}/lib/libvulkan.so)
 endif()
 


### PR DESCRIPTION
Include VulkanSDK as system headers, otherwise Apple Clang spams warnings about `-Wnullability-completeness`. Also use `.dylib` extension for shared libraries.

With these changes, the project runs on MacOS.

<img width="1279" height="748" alt="screenshot" src="https://github.com/user-attachments/assets/393628b6-d445-4117-a58e-9bf148985e28" />