### PR TITLE
fix broken link

### DIFF
--- a/tutorial/docs/index.md
+++ b/tutorial/docs/index.md
@@ -514,7 +514,7 @@ for (auto& index : shapes[0].mesh.indices) {
 	Vertex v{
 		.pos = { attrib.vertices[index.vertex_index * 3], -attrib.vertices[index.vertex_index * 3 + 1], attrib.vertices[index.vertex_index * 3 + 2] },
 		.normal = { attrib.normals[index.normal_index * 3], -attrib.normals[index.normal_index * 3 + 1], attrib.normals[index.normal_index * 3 + 2] },
-		.uv = { attrib.texcoords[index.texcoord_index * 2], 1.0 - attrib.texcoords[index.texcoord_index * 2+ 1] }
+		.uv = { attrib.texcoords[index.texcoord_index * 2], 1.0 - attrib.texcoords[index.texcoord_index * 2 + 1] }
 	};
 	vertices.push_back(v);
 	indices.push_back(indices.size());


### PR DESCRIPTION
The double parentheses turned the link into the following invalid form.
`https://www.howtovulkan.com/(https://docs.vulkan.org/spec/latest/chapters/formats.html#features-required-format-support)`