### PR TITLE
Assets folder not being copied to bin on build

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -74,3 +74,8 @@ target_link_libraries(${NAME} PRIVATE ${SDL_LIBRARY} ktx ${Slang_LIBRARY})
 if (NOT WIN32)
     target_link_libraries(${NAME} PRIVATE glm::glm-header-only)
 endif()
+
+add_custom_command(TARGET ${NAME} POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+        ${CMAKE_CURRENT_SOURCE_DIR}/assets
+        ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets)


### PR DESCRIPTION
Hello,

Project doesn't run correctly out of the box due to missing assets from the bin directory. Coupled with very indirect error messaging "Call returned an error" making it not so trivial to debug for beginners. I didn't modify tutorial texts due to the tutorial already skipping over much of the cmake configuration. 

Not sure if makes a difference i'm using clang and ninja for generator.

NOTE: the CmakeLists.txt diff was generated with AI, which conflicts with "AI generated pull requests and issues will be rejected.". 

If this will be rejected i hope someone to add proper fix. Reason for AI was due to my poor cmake skills. 

Thanks for great tutorial.