### PR TITLE
ktx/lib/texture.c: memory leak in ktxTextureInt_constructFromStream

### DIFF
--- a/source/external/ktx/lib/texture.c
+++ b/source/external/ktx/lib/texture.c
@@ -376,8 +376,8 @@ ktxTextureInt_constructFromStream(ktxTextureInt* This,
             if (!(createFlags & KTX_TEXTURE_CREATE_RAW_KVDATA_BIT)) {
                 result = ktxHashList_Deserialize(&super->kvDataHead,
                                                  kvdLen, pKvd);
+                free(pKvd);
                 if (result != KTX_SUCCESS) {
-                    free(pKvd);
                     return result;
                 }
             } else {


### PR DESCRIPTION
This backports upstream commit
KhronosGroup/KTX-Software @ [c9dea751994a3d77a153aa44ff4910422c9fb212](https://github.com/KhronosGroup/KTX-Software/commit/c9dea751994a3d77a153aa44ff4910422c9fb212)