### PR TITLE
VkDescriptorSetLayoutBinding: explicitly initialize .binding field

### DIFF
--- a/source/main.cpp
+++ b/source/main.cpp
@@ -384,7 +384,7 @@ int main(int argc, char* argv[])
 	// Descriptor (indexing)
 	VkDescriptorBindingFlags descVariableFlag{ VK_DESCRIPTOR_BINDING_VARIABLE_DESCRIPTOR_COUNT_BIT };
 	VkDescriptorSetLayoutBindingFlagsCreateInfo descBindingFlags{ .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO, .bindingCount = 1, .pBindingFlags = &descVariableFlag };
-	VkDescriptorSetLayoutBinding descLayoutBindingTex{ .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, .descriptorCount = static_cast<uint32_t>(textures.size()), .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT };
+	VkDescriptorSetLayoutBinding descLayoutBindingTex{ .binding = 0, .descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, .descriptorCount = static_cast<uint32_t>(textures.size()), .stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT };
 	VkDescriptorSetLayoutCreateInfo descLayoutTexCI{ .sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO, .pNext = &descBindingFlags, .bindingCount = 1, .pBindings = &descLayoutBindingTex };
 	chk(vkCreateDescriptorSetLayout(device, &descLayoutTexCI, nullptr, &descriptorSetLayoutTex));
 	VkDescriptorPoolSize poolSize{ .type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, .descriptorCount = static_cast<uint32_t>(textures.size()) };

--- a/tutorial/docs/index.md
+++ b/tutorial/docs/index.md
@@ -943,6 +943,7 @@ VkDescriptorSetLayoutBindingFlagsCreateInfo descBindingFlags{
 	.pBindingFlags = &descVariableFlag
 };
 VkDescriptorSetLayoutBinding descLayoutBindingTex{
+	.binding = 0,
 	.descriptorType = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER,
 	.descriptorCount = static_cast<uint32_t>(textures.size()),
 	.stageFlags = VK_SHADER_STAGE_FRAGMENT_BIT


### PR DESCRIPTION
Though this does not change behavior, it does clarify precisely where binding indices are defined.