### PR TITLE
Fix build with newer Vulkan SDKs

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -43,7 +43,9 @@ set(KTX_SOURCES
     ${KTX_DIR}/lib/vkloader.c)
 add_library(ktx STATIC ${KTX_SOURCES})
 
-if (APPLE)
+if (TARGET Vulkan::Vulkan)
+    target_link_libraries(ktx PUBLIC Vulkan::Vulkan)
+elseif (APPLE)
     target_link_libraries(ktx PUBLIC $ENV{VULKAN_SDK}/lib/libvulkan.dylib)
 elseif (NOT WIN32)
     target_link_libraries(ktx PUBLIC $ENV{VULKAN_SDK}/lib/libvulkan.so)


### PR DESCRIPTION
libvulkan.so has changed place. It's at:
1.4.350.1/x86_64/lib/VulkanLoader/lib/libvulkan.so now.

Fix by linking to the target if it exists, otherwise fallback to old code path so we don't break old SDKs that might not exported named cmake targets.